### PR TITLE
Joining the new method of spreading the internships over multiple entries, read for more

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Stack Info allows you to explore and find tech stacks used by startups and corpo
 |[Synapse backend intern](https://synapseanalytics.recruitee.com/o/backend-engineering-internship)| Remote | Open - python django backend |
 |[Synapse frontend intern](https://synapseanalytics.recruitee.com/o/frontend-engineering-internship-cairo)| Remote | Open - React.js |
 |[Synapse mobile intern](https://synapseanalytics.recruitee.com/o/react-native-mobile-development-internship)| Remote | Open - React Native |
+|[Synapse UI/UX intern](https://synapseanalytics.recruitee.com/o/ui-ux-internship)| Remote | Open - Figma |
 |[Synapse DevOps intern](https://synapseanalytics.recruitee.com/o/devops-engineering-internship)| Remote | Open - Docker, python, linux, git |
 |[Synapse ML/CV intern](https://synapseanalytics.recruitee.com/o/machine-learning-engineering-internship-computer-vision)| Remote | Open - Python, SQL, TF2/Pytorch, git|
 |[Synapse data science intern](https://synapseanalytics.recruitee.com/o/data-science-internship)| Remote | Open - Python/R & Database |

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Stack Info allows you to explore and find tech stacks used by startups and corpo
 |[Synapse ML/CV intern](https://synapseanalytics.recruitee.com/o/machine-learning-engineering-internship-computer-vision)| Remote | Open - Python, SQL, TF2/Pytorch, git|
 |[Synapse data science intern](https://synapseanalytics.recruitee.com/o/data-science-internship)| Remote | Open - Python/R & Database |
 |[Synapse data science consultant intern](https://synapseanalytics.recruitee.com/o/data-science-consultant-internship)| Remote | Open - MS office / excel |
+|[Synapse product owner intern](https://synapseanalytics.recruitee.com/o/product-owner-internship)| Cairo | Open - Agile, communication skills, management skills|
 |[Technocolabs Softwares](https://docs.google.com/forms/d/e/1FAIpQLSdytYOR6tWfpVBVMb6HhkvPyqPqoDfRFh40fT4y7uosLsk5NA/viewform) | Remote | Open - Multiple Interns |
 |[The Sparks Foundation GRIP](https://internship.thesparksfoundation.info/#steps-to-apply) | Remote | Open - <b>Unpaid Intern</b> |
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Stack Info allows you to explore and find tech stacks used by startups and corpo
 |[Seuqel Solutions](https://wuzzuf.net/internship/zhrsQuiWUeuB-MERN-Full-Stack-Developer-Internship-Seuqel-Solutions-Cairo-Egypt?o=11&l=sp&t=sj&a=internship%7Csearch-v3%7Cnavbl&s=31562264)| Cairo | Open- <b>Paid Intern</b> -MERN Full Stack Intern |
 |[Synapse backend intern](https://synapseanalytics.recruitee.com/o/backend-engineering-internship)| Remote | Open - python django backend |
 |[Synapse frontend intern](https://synapseanalytics.recruitee.com/o/frontend-engineering-internship-cairo)| Remote | Open - React.js |
+|[Synapse mobile intern](https://synapseanalytics.recruitee.com/o/react-native-mobile-development-internship)| Remote | Open - React Native |
 |[Synapse DevOps intern](https://synapseanalytics.recruitee.com/o/devops-engineering-internship)| Remote | Open - Docker, python, linux, git |
 |[Synapse ML/CV intern](https://synapseanalytics.recruitee.com/o/machine-learning-engineering-internship-computer-vision)| Remote | Open - Python, SQL, TF2/Pytorch, git|
 |[Synapse data science intern](https://synapseanalytics.recruitee.com/o/data-science-internship)| Remote | Open - Python/R & Database |

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Stack Info allows you to explore and find tech stacks used by startups and corpo
 |[Seuqel Solutions](https://wuzzuf.net/internship/jKuGfqbQLV8X-Node-JS---Backend-Developer-Internship-Seuqel-Solutions-Cairo-Egypt?l=dbp&t=rj&o=1&a=S1%7CC%7CM%7CV2)| Cairo | Open- <b>Paid Intern</b> -Backend Intern |
 |[Seuqel Solutions](https://wuzzuf.net/internship/zhrsQuiWUeuB-MERN-Full-Stack-Developer-Internship-Seuqel-Solutions-Cairo-Egypt?o=11&l=sp&t=sj&a=internship%7Csearch-v3%7Cnavbl&s=31562264)| Cairo | Open- <b>Paid Intern</b> -MERN Full Stack Intern |
 |[Synapse backend intern](https://synapseanalytics.recruitee.com/o/backend-engineering-internship)| Remote | Open - python django backend |
+|[Synapse DevOps intern](https://synapseanalytics.recruitee.com/o/devops-engineering-internship)| Remote | Open - Docker, python, linux, git |
 |[Synapse data science intern](https://synapseanalytics.recruitee.com/o/data-science-internship)| Remote | Open - Python/R & Database |
 |[Synapse data science consultant intern](https://synapseanalytics.recruitee.com/o/data-science-consultant-internship)| Remote | Open - MS office / excel |
 |[Technocolabs Softwares](https://docs.google.com/forms/d/e/1FAIpQLSdytYOR6tWfpVBVMb6HhkvPyqPqoDfRFh40fT4y7uosLsk5NA/viewform) | Remote | Open - Multiple Interns |

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Stack Info allows you to explore and find tech stacks used by startups and corpo
 |[Synapse backend intern](https://synapseanalytics.recruitee.com/o/backend-engineering-internship)| Remote | Open - python django backend |
 |[Synapse frontend intern](https://synapseanalytics.recruitee.com/o/frontend-engineering-internship-cairo)| Remote | Open - React.js |
 |[Synapse DevOps intern](https://synapseanalytics.recruitee.com/o/devops-engineering-internship)| Remote | Open - Docker, python, linux, git |
+|[Synapse ML/CV intern](https://synapseanalytics.recruitee.com/o/machine-learning-engineering-internship-computer-vision)| Remote | Open - Python, SQL, TF2/Pytorch, git|
 |[Synapse data science intern](https://synapseanalytics.recruitee.com/o/data-science-internship)| Remote | Open - Python/R & Database |
 |[Synapse data science consultant intern](https://synapseanalytics.recruitee.com/o/data-science-consultant-internship)| Remote | Open - MS office / excel |
 |[Technocolabs Softwares](https://docs.google.com/forms/d/e/1FAIpQLSdytYOR6tWfpVBVMb6HhkvPyqPqoDfRFh40fT4y7uosLsk5NA/viewform) | Remote | Open - Multiple Interns |

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Stack Info allows you to explore and find tech stacks used by startups and corpo
 |[Seuqel Solutions](https://wuzzuf.net/internship/IqkUjm26ktyu-Front-End-Developer---InternshipRemote-Seuqel-Solutions-Cairo-Egypt?o=5&l=sp&t=sj&a=internship%7Csearch-v3%7Cnavbl&s=31562264) | Remote | Open- <b>Paid Intern</b> -Frontend Intern |
 |[Seuqel Solutions](https://wuzzuf.net/internship/jKuGfqbQLV8X-Node-JS---Backend-Developer-Internship-Seuqel-Solutions-Cairo-Egypt?l=dbp&t=rj&o=1&a=S1%7CC%7CM%7CV2)| Cairo | Open- <b>Paid Intern</b> -Backend Intern |
 |[Seuqel Solutions](https://wuzzuf.net/internship/zhrsQuiWUeuB-MERN-Full-Stack-Developer-Internship-Seuqel-Solutions-Cairo-Egypt?o=11&l=sp&t=sj&a=internship%7Csearch-v3%7Cnavbl&s=31562264)| Cairo | Open- <b>Paid Intern</b> -MERN Full Stack Intern |
+|[Synapse backend intern](https://synapseanalytics.recruitee.com/o/backend-engineering-internship)| Remote | Open - python django backend |
 |[Technocolabs Softwares](https://docs.google.com/forms/d/e/1FAIpQLSdytYOR6tWfpVBVMb6HhkvPyqPqoDfRFh40fT4y7uosLsk5NA/viewform) | Remote | Open - Multiple Interns |
 |[The Sparks Foundation GRIP](https://internship.thesparksfoundation.info/#steps-to-apply) | Remote | Open - <b>Unpaid Intern</b> |
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Stack Info allows you to explore and find tech stacks used by startups and corpo
 |[Seuqel Solutions](https://wuzzuf.net/internship/jKuGfqbQLV8X-Node-JS---Backend-Developer-Internship-Seuqel-Solutions-Cairo-Egypt?l=dbp&t=rj&o=1&a=S1%7CC%7CM%7CV2)| Cairo | Open- <b>Paid Intern</b> -Backend Intern |
 |[Seuqel Solutions](https://wuzzuf.net/internship/zhrsQuiWUeuB-MERN-Full-Stack-Developer-Internship-Seuqel-Solutions-Cairo-Egypt?o=11&l=sp&t=sj&a=internship%7Csearch-v3%7Cnavbl&s=31562264)| Cairo | Open- <b>Paid Intern</b> -MERN Full Stack Intern |
 |[Synapse backend intern](https://synapseanalytics.recruitee.com/o/backend-engineering-internship)| Remote | Open - python django backend |
+|[Synapse data science consultant intern](https://synapseanalytics.recruitee.com/o/data-science-consultant-internship)| Remote | Open - MS office / excel |
 |[Technocolabs Softwares](https://docs.google.com/forms/d/e/1FAIpQLSdytYOR6tWfpVBVMb6HhkvPyqPqoDfRFh40fT4y7uosLsk5NA/viewform) | Remote | Open - Multiple Interns |
 |[The Sparks Foundation GRIP](https://internship.thesparksfoundation.info/#steps-to-apply) | Remote | Open - <b>Unpaid Intern</b> |
 

--- a/README.md
+++ b/README.md
@@ -55,14 +55,14 @@ Stack Info allows you to explore and find tech stacks used by startups and corpo
 |[Seuqel Solutions](https://wuzzuf.net/internship/IqkUjm26ktyu-Front-End-Developer---InternshipRemote-Seuqel-Solutions-Cairo-Egypt?o=5&l=sp&t=sj&a=internship%7Csearch-v3%7Cnavbl&s=31562264) | Remote | Open- <b>Paid Intern</b> -Frontend Intern |
 |[Seuqel Solutions](https://wuzzuf.net/internship/jKuGfqbQLV8X-Node-JS---Backend-Developer-Internship-Seuqel-Solutions-Cairo-Egypt?l=dbp&t=rj&o=1&a=S1%7CC%7CM%7CV2)| Cairo | Open- <b>Paid Intern</b> -Backend Intern |
 |[Seuqel Solutions](https://wuzzuf.net/internship/zhrsQuiWUeuB-MERN-Full-Stack-Developer-Internship-Seuqel-Solutions-Cairo-Egypt?o=11&l=sp&t=sj&a=internship%7Csearch-v3%7Cnavbl&s=31562264)| Cairo | Open- <b>Paid Intern</b> -MERN Full Stack Intern |
-|[Synapse backend intern](https://synapseanalytics.recruitee.com/o/backend-engineering-internship)| Remote | Open - python django backend |
-|[Synapse frontend intern](https://synapseanalytics.recruitee.com/o/frontend-engineering-internship-cairo)| Remote | Open - React.js |
-|[Synapse mobile intern](https://synapseanalytics.recruitee.com/o/react-native-mobile-development-internship)| Remote | Open - React Native |
-|[Synapse UI/UX intern](https://synapseanalytics.recruitee.com/o/ui-ux-internship)| Remote | Open - Figma |
-|[Synapse DevOps intern](https://synapseanalytics.recruitee.com/o/devops-engineering-internship)| Remote | Open - Docker, python, linux, git |
-|[Synapse ML/CV intern](https://synapseanalytics.recruitee.com/o/machine-learning-engineering-internship-computer-vision)| Remote | Open - Python, SQL, TF2/Pytorch, git|
-|[Synapse data science intern](https://synapseanalytics.recruitee.com/o/data-science-internship)| Remote | Open - Python/R & Database |
-|[Synapse data science consultant intern](https://synapseanalytics.recruitee.com/o/data-science-consultant-internship)| Remote | Open - MS office / excel |
+|[Synapse backend intern](https://synapseanalytics.recruitee.com/o/backend-engineering-internship)| Cairo/Hybrid | Open - python django backend |
+|[Synapse frontend intern](https://synapseanalytics.recruitee.com/o/frontend-engineering-internship-cairo)| Cairo/Hybrid | Open - React.js |
+|[Synapse mobile intern](https://synapseanalytics.recruitee.com/o/react-native-mobile-development-internship)| Cairo/Hybrid | Open - React Native |
+|[Synapse UI/UX intern](https://synapseanalytics.recruitee.com/o/ui-ux-internship)| Cairo/Hybrid | Open - Figma |
+|[Synapse DevOps intern](https://synapseanalytics.recruitee.com/o/devops-engineering-internship)| Cairo/Hybrid | Open - Docker, python, linux, git |
+|[Synapse ML/CV intern](https://synapseanalytics.recruitee.com/o/machine-learning-engineering-internship-computer-vision)| Cairo/Hybrid | Open - Python, SQL, TF2/Pytorch, git|
+|[Synapse data science intern](https://synapseanalytics.recruitee.com/o/data-science-internship)| Cairo/Hybrid | Open - Python/R & Database |
+|[Synapse data science consultant intern](https://synapseanalytics.recruitee.com/o/data-science-consultant-internship)| Cairo | Open - MS office / excel |
 |[Synapse product owner intern](https://synapseanalytics.recruitee.com/o/product-owner-internship)| Cairo | Open - Agile, communication skills, management skills|
 |[Technocolabs Softwares](https://docs.google.com/forms/d/e/1FAIpQLSdytYOR6tWfpVBVMb6HhkvPyqPqoDfRFh40fT4y7uosLsk5NA/viewform) | Remote | Open - Multiple Interns |
 |[The Sparks Foundation GRIP](https://internship.thesparksfoundation.info/#steps-to-apply) | Remote | Open - <b>Unpaid Intern</b> |

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Stack Info allows you to explore and find tech stacks used by startups and corpo
 |[Seuqel Solutions](https://wuzzuf.net/internship/jKuGfqbQLV8X-Node-JS---Backend-Developer-Internship-Seuqel-Solutions-Cairo-Egypt?l=dbp&t=rj&o=1&a=S1%7CC%7CM%7CV2)| Cairo | Open- <b>Paid Intern</b> -Backend Intern |
 |[Seuqel Solutions](https://wuzzuf.net/internship/zhrsQuiWUeuB-MERN-Full-Stack-Developer-Internship-Seuqel-Solutions-Cairo-Egypt?o=11&l=sp&t=sj&a=internship%7Csearch-v3%7Cnavbl&s=31562264)| Cairo | Open- <b>Paid Intern</b> -MERN Full Stack Intern |
 |[Synapse backend intern](https://synapseanalytics.recruitee.com/o/backend-engineering-internship)| Remote | Open - python django backend |
+|[Synapse data science intern](https://synapseanalytics.recruitee.com/o/data-science-internship)| Remote | Open - Python/R & Database |
 |[Synapse data science consultant intern](https://synapseanalytics.recruitee.com/o/data-science-consultant-internship)| Remote | Open - MS office / excel |
 |[Technocolabs Softwares](https://docs.google.com/forms/d/e/1FAIpQLSdytYOR6tWfpVBVMb6HhkvPyqPqoDfRFh40fT4y7uosLsk5NA/viewform) | Remote | Open - Multiple Interns |
 |[The Sparks Foundation GRIP](https://internship.thesparksfoundation.info/#steps-to-apply) | Remote | Open - <b>Unpaid Intern</b> |

--- a/README.md
+++ b/README.md
@@ -55,7 +55,6 @@ Stack Info allows you to explore and find tech stacks used by startups and corpo
 |[Seuqel Solutions](https://wuzzuf.net/internship/IqkUjm26ktyu-Front-End-Developer---InternshipRemote-Seuqel-Solutions-Cairo-Egypt?o=5&l=sp&t=sj&a=internship%7Csearch-v3%7Cnavbl&s=31562264) | Remote | Open- <b>Paid Intern</b> -Frontend Intern |
 |[Seuqel Solutions](https://wuzzuf.net/internship/jKuGfqbQLV8X-Node-JS---Backend-Developer-Internship-Seuqel-Solutions-Cairo-Egypt?l=dbp&t=rj&o=1&a=S1%7CC%7CM%7CV2)| Cairo | Open- <b>Paid Intern</b> -Backend Intern |
 |[Seuqel Solutions](https://wuzzuf.net/internship/zhrsQuiWUeuB-MERN-Full-Stack-Developer-Internship-Seuqel-Solutions-Cairo-Egypt?o=11&l=sp&t=sj&a=internship%7Csearch-v3%7Cnavbl&s=31562264)| Cairo | Open- <b>Paid Intern</b> -MERN Full Stack Intern |
-|[Synapse](https://synapseanalytics.recruitee.com/)| Cairo/Remote | Open - backend, frontend, devops, ML/CV, data science |
 |[Technocolabs Softwares](https://docs.google.com/forms/d/e/1FAIpQLSdytYOR6tWfpVBVMb6HhkvPyqPqoDfRFh40fT4y7uosLsk5NA/viewform) | Remote | Open - Multiple Interns |
 |[The Sparks Foundation GRIP](https://internship.thesparksfoundation.info/#steps-to-apply) | Remote | Open - <b>Unpaid Intern</b> |
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Stack Info allows you to explore and find tech stacks used by startups and corpo
 |[Seuqel Solutions](https://wuzzuf.net/internship/jKuGfqbQLV8X-Node-JS---Backend-Developer-Internship-Seuqel-Solutions-Cairo-Egypt?l=dbp&t=rj&o=1&a=S1%7CC%7CM%7CV2)| Cairo | Open- <b>Paid Intern</b> -Backend Intern |
 |[Seuqel Solutions](https://wuzzuf.net/internship/zhrsQuiWUeuB-MERN-Full-Stack-Developer-Internship-Seuqel-Solutions-Cairo-Egypt?o=11&l=sp&t=sj&a=internship%7Csearch-v3%7Cnavbl&s=31562264)| Cairo | Open- <b>Paid Intern</b> -MERN Full Stack Intern |
 |[Synapse backend intern](https://synapseanalytics.recruitee.com/o/backend-engineering-internship)| Remote | Open - python django backend |
+|[Synapse frontend intern](https://synapseanalytics.recruitee.com/o/frontend-engineering-internship-cairo)| Remote | Open - React.js |
 |[Synapse DevOps intern](https://synapseanalytics.recruitee.com/o/devops-engineering-internship)| Remote | Open - Docker, python, linux, git |
 |[Synapse data science intern](https://synapseanalytics.recruitee.com/o/data-science-internship)| Remote | Open - Python/R & Database |
 |[Synapse data science consultant intern](https://synapseanalytics.recruitee.com/o/data-science-consultant-internship)| Remote | Open - MS office / excel |


### PR DESCRIPTION
I noticed the new way of spreading multiple internships over multiple entries even if they are from the same company, this method was used for PRs #74 and #72 which proved more convenient for users to only open links they are concerned with instead of opening a company website and searching through all of it.

Also would be beneficial when companies close some internship entries but leave other departments open for candidates so we would only remove the closed ones and not the entire company entry in the readme